### PR TITLE
updated dashboard action to work with the new interest table

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -45,7 +45,8 @@ class ProjectsController < ApplicationController
     @latest_project = current_user.projects.accepted.order(created_at: :desc).first
     @upcoming_projects = current_user.projects.accepted.where('deadline > ?', DateTime.now)
     @user_points = current_user.projects.sum(:points)
-    @recommended_projects = current_user.projects.pending.where(category: current_user.interest)
+    user_interest_names = current_user.interests.map(&:name)
+    @recommended_projects = current_user.projects.pending.where(category: user_interest_names)
   end
 
   private


### PR DESCRIPTION
It was giving us an error since we removed the original interest column from users. It should be working now with this fix.