### PR TITLE
Fixing add link in show page

### DIFF
--- a/app/assets/stylesheets/pages/_projects-index.scss
+++ b/app/assets/stylesheets/pages/_projects-index.scss
@@ -53,3 +53,10 @@
   display: flex;
   flex-direction: column;
 }
+
+// Remove default link styling
+
+.no-link-style {
+  text-decoration: none;
+  color: inherit;
+}

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -34,7 +34,7 @@ class ProjectsController < ApplicationController
   def update
     @project = Project.find(params[:id])
     if @project.update(project_params)
-      redirect_to dashboard_path, notice: 'This project was updated successfully!'
+      redirect_to projects_path, notice: 'This project was updated successfully!'
     else
       render 'show'
     end

--- a/app/views/projects/dashboard.html.erb
+++ b/app/views/projects/dashboard.html.erb
@@ -45,15 +45,6 @@
           <div class="project-card">
             <p class="project-name">Name: <%= project.name %></p>
             <p class="project-category">Category: <%= project.category %></p>
-              <%# MOVE THE LINK BELOW TO THE PROJECTS SHOW PAGE LATER :) %>
-              <% if project.pending? %>
-                <%= simple_form_for project, url: project_path(project) do |f| %>
-                <%= f.input :status, as: :hidden, input_html: { value: 'accepted' } %>
-                <div class="button-container">
-                  <%= f.submit 'Add', class: 'btn accept-button' %>
-                </div>
-                <% end %>
-              <% end %>
             <%= link_to '', project_path(project), class: "card-link" %>
           </div>
           <% end %>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -26,7 +26,7 @@
           <div class="category-tag">
             <p><%= project.category %></p>
           </div>
-          <h6><strong><%= project.name %></strong></h6>
+          <h6><strong><%= link_to project.name, project_path(project), class: 'no-link-style' %></strong></h6>
           <%# <p><%= project.description</p>  %>
           <div class="content-bottom">
             <p>Deadline:<br><small><%= project.deadline %></small></p>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1,4 +1,4 @@
-<%# <%= render "shared/navbar"%>
+<%# <%= render "shared/navbar" %>
 <div class="row project-list justify-content-center">
   <div class="container">
   <%# title %>
@@ -22,9 +22,15 @@
           <div class="category-tag">
             <p><%= @project.category %></p>
           </div>
-            <button class="green-btn">
-              <%= link_to "Add", projects_path%>
-            </button>
+            <%# Update a pending project to accepted to display in projects list %>
+            <% if @project.pending? %>
+              <%= simple_form_for @project, url: project_path(@project) do |f| %>
+              <%= f.input :status, as: :hidden, input_html: { value: 'accepted' } %>
+              <div class="button-container">
+                <%= f.submit 'Add', class: 'green-btn' %>
+              </div>
+              <% end %>
+            <% end %>
           </div>
             <h6><strong><%= @project.name %></strong></h6>
             <p><%= @project.description%></p>


### PR DESCRIPTION
I removed the initial 'add' button that I had in the dashboard.
I also fixed the add button in the show page so it should update the project status from pending to accepted and then display it on the projects list page.

Last thing is I made the project name a link to the project show page so we can view the details of a project at any time.

<img width="530" alt="Screen Shot 2023-08-09 at 9 41 29" src="https://github.com/KarasuGummi/ontrack/assets/115050264/c13a47df-8737-43db-95bc-c02c6a0ee2c6">
<img width="578" alt="Screen Shot 2023-08-09 at 9 41 50" src="https://github.com/KarasuGummi/ontrack/assets/115050264/f0974623-31f1-4951-bf08-934054aef5bf">


