### PR TITLE
Updating projects table

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -50,7 +50,8 @@ class ProjectsController < ApplicationController
     user_interest_names = current_user.interests.map(&:name)
     @recommended_projects = current_user.projects.pending.where(
       subject: @user.subject,
-      interest: user_interest_names
+      interest: user_interest_names,
+      learning_goal: @user.learning_goal
     )
   end
 

--- a/app/views/projects/dashboard.html.erb
+++ b/app/views/projects/dashboard.html.erb
@@ -55,6 +55,8 @@
     <div class="card-body">
       <h6 class="card-title"><strong><%= project.name %></strong></h6>
       <p class="card-text">Subject: <%= project.subject %></p>
+      <p class="card-text">Topic: <%= project.learning_goal %></p>
+
       <%= link_to '➡️ Try it now!', project_path(project), class: "btn btn-light" %>
       <% end %>
     </div>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -34,6 +34,17 @@
           </div>
             <h6><strong><%= @project.name %></strong></h6>
             <p><%= @project.description%></p>
+
+            <h6><strong>Project Steps:</strong></h6>
+            <p><%= @project.steps %></p>
+
+            <h6><strong>Vocab Words:</strong></h6>
+            <ul>
+              <% @project.vocab_words.each do |word| %>
+                <li><%= word %></li>
+              <% end %>
+            </ul>
+
           <div class="content-bottom">
             <p>Deadline:<br><small><%= @project.deadline %></small></p>
           </div>

--- a/db/migrate/20230812123625_add_columns_to_projects.rb
+++ b/db/migrate/20230812123625_add_columns_to_projects.rb
@@ -1,0 +1,7 @@
+class AddColumnsToProjects < ActiveRecord::Migration[7.0]
+  def change
+    add_column :projects, :learning_goal, :string
+    add_column :projects, :steps, :text
+    add_column :projects, :vocab_words, :string, array: true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_12_023422) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_12_123625) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -76,6 +76,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_12_023422) do
     t.datetime "updated_at", null: false
     t.text "description"
     t.string "interest"
+    t.string "learning_goal"
+    t.text "steps"
+    t.string "vocab_words", default: [], array: true
     t.index ["user_id"], name: "index_projects_on_user_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -133,7 +133,9 @@ language_drawing2 = Project.create!(
   points: 40,
   user: kevin,
   interest: 'drawing',
-  learning_goal: 'past tense action verbs'
+  learning_goal: 'past tense action verbs',
+  steps: 'Step 1: Choose your setting. Step 2: Choose your characters. Step 3: Think of 4 -5 main points for your story. Step 4: Make a list of vocab words that you will use. Step 5: Start drawing!',
+  vocab_words: ['bailar', 'comer', 'saltar', 'correr', 'cantar']
 )
 language_drawing2_question = Question.create!(
   question_content: 'How do you say dance in spanish?',

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -65,7 +65,7 @@ kevin = User.create!(
   subject: 'Spanish',
   buddy: kevin_buddy,
   grade: 'college',
-  learning_goal: 'vocabulary'
+  learning_goal: 'past tense action verbs'
 )
 
 curtis = User.create!(
@@ -105,13 +105,14 @@ puts 'Creating projects...'
 # *****************KEVIN PROJECTS*****************
 language_drawing = Project.create!(
   name: 'Learn Spanish by Drawing Animals',
-  subject: 'Language',
+  subject: 'Spanish',
   description: 'Welcome to our fun and engaging Spanish language learning experience, where we will dive into the world of animals and use drawing as a powerful tool to enhance your language skills! In this interactive and creative lesson, you will discover how drawing can be an exciting way to learn Spanish vocabulary and improve your communication skills.',
   deadline: DateTime.now,
   status: :accepted,
   points: 50,
   user: kevin,
-  interest: 'drawing'
+  interest: 'drawing',
+  learning_goal: 'past tense action verbs'
 )
 language_drawing_question = Question.create!(
   question_content: 'Can you mention three animals we drew today in Spanish?',
@@ -125,13 +126,14 @@ Answer.create!(
 
 language_drawing2 = Project.create!(
   name: 'Learn Spanish by Creating a Comic Book',
-  subject: 'Language',
+  subject: 'Spanish',
   description: 'Learn basic spanish verbs by creating a comic book! Choose a setting that appeals to you, choose your characters, and make a list of what their actions. Your goal is to use 5 - 10 action verbs in your comic strip.',
   deadline: DateTime.now,
   status: :pending,
   points: 40,
   user: kevin,
-  interest: 'drawing'
+  interest: 'drawing',
+  learning_goal: 'past tense action verbs'
 )
 language_drawing2_question = Question.create!(
   question_content: 'How do you say dance in spanish?',
@@ -145,13 +147,14 @@ Answer.create!(
 
 language_starwars = Project.create!(
   name: 'A New Hope: Exploring Spanish Vocabulary Through Star Wars',
-  subject: 'Language',
+  subject: 'Spanish',
   description: 'The objective of this lesson is to introduce students to Spanish vocabulary by using terms and concepts from the Star Wars universe. Students will engage with popular Star Wars characters, settings, and phrases while expanding their language skills.',
   deadline: DateTime.parse('2023-09-01 17:30:00'),
   status: :pending,
   points: 200,
   user: kevin,
-  interest: 'star wars'
+  interest: 'star wars',
+  learning_goal: 'emotions and feelings'
 )
 language_starwars_question = Question.create!(
   question_content: 'What is the Spanish translation for "space" and "planet," two vocabulary words related to Star Wars?',


### PR DESCRIPTION
I updated the projects table to include vocab_words (array of strings),  a learning goal, and steps.

I also added the learning goal to the dashboard action so now we will query for more specific projects.

In the future when we prompt chat gpt, we can now send the user's subject, interest, and learning goal (for example: I want to study spanish, I am interested in star wars and anime, and my goal is to study past tense verbs).

I updated the seeds to include these new columns just as a test and everything seems to be working.

The style for the projects show page can be improved at some point :)

<img width="497" alt="Screen Shot 2023-08-12 at 21 47 04" src="https://github.com/KarasuGummi/ontrack/assets/115050264/a7dc8df5-b325-45ab-85ac-25bc87a09484">
<img width="499" alt="Screen Shot 2023-08-12 at 21 46 05" src="https://github.com/KarasuGummi/ontrack/assets/115050264/31f3e1d4-d4f9-4e95-ae48-88518ed3b8b8">
<img width="515" alt="Screen Shot 2023-08-12 at 22 03 39" src="https://github.com/KarasuGummi/ontrack/assets/115050264/cc387b4a-c24c-41c4-a84d-2e141817b720">
