### PR TITLE
Changing chatgpt projects to instances

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -37,7 +37,7 @@ class ProjectsController < ApplicationController
         project_to_accept.update(status: 'accepted')
         flash[:notice] = 'Recommended project added!'
       end
-      redirect_to projects_path
+      # redirect_to projects_path
     else
       puts "Project Errors: #{@project.errors}"
       render 'new'

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -4,17 +4,12 @@ class ProjectsController < ApplicationController
   def index
     @buddy = current_user.buddy
     @projects = Project.all
-    # I added this line so that we can display only projects that have been accepted
     @accepted_projects = current_user.projects.accepted
   end
 
   def new
     @project = Project.new
     @buddy = current_user.buddy
-    @user_interest = current_user.interests.sample.name # Store user interest for use in the view
-    @subject = ""
-    @learning_goal = ""
-    @recommendation = generate_recommendations(@subject, @learning_goal, @user_interest)
   end
 
 
@@ -26,21 +21,30 @@ class ProjectsController < ApplicationController
   def create
     @buddy = current_user.buddy
     @user = current_user
-    @project = Project.new(project_params)
     project_subject = params[:project][:subject]
     project_learning_goal = params[:project][:learning_goal]
     user_interest = current_user.interests.sample.name
 
-    # Call the method to generate recommendations
     @recommendation = generate_recommendations(project_subject, project_learning_goal, user_interest)
 
-    if params[:add_project]
-      selected_suggestion = @recommendation[params[:add_project].to_i]
-      create_pending_project_from_suggestion(selected_suggestion)
+    @project = Project.new(@recommendation)
+    @project.user = current_user
+
+    if @project.save
+      flash[:notice] = 'Project created!'
+      if params[:add_project]
+        project_to_accept = Project.find(params[:add_project])
+        project_to_accept.update(status: 'accepted')
+        flash[:notice] = 'Recommended project added!'
+      end
+      redirect_to projects_path
+    else
+      puts "Project Errors: #{@project.errors}"
+      render 'new'
     end
 
-    render 'new'
   end
+
 
   def destroy
     @project = Project.find(params[:id])
@@ -82,8 +86,9 @@ class ProjectsController < ApplicationController
     prompt = <<~PROMPT
       Please suggest one project for my #{subject} class.
       Please limit the words of the description for the project to less than 12 words.
-      Please also limit the instructions to 3 - 5 steps max with each step having less than 12 words.
+      Please also limit the instructions to 4 steps with each step having less than 12 words.
       The project should be about #{learning_goal} and the project should incorporate #{user_interest}.
+      There should only be 5 vocab words per project.
       For the project, provide the following information:
       - Title
       - Description
@@ -96,31 +101,27 @@ class ProjectsController < ApplicationController
     puts "Generated Prompt: #{prompt}"
     openai_service = OpenaiService.new(prompt)
     response = openai_service.call
-    # puts "API Response: #{response}"
-
     suggestion = response["choices"][0]["message"]["content"]
-
     formatted_suggestion = suggestion.split("\n")
+    puts "Formatted suggestions: #{formatted_suggestion.inspect}"
 
-    structured_recommendation = { "suggested_project" => formatted_suggestion }
-    structured_recommendation
-
-    p structured_recommendation
-  end
-
-  def project_params
-    params.require(:project).permit(:name, :deadline, :subject, :learning_goal, :status)
-  end
-
-  def create_pending_project_from_suggestion
-    @project = Project.new(
-      name: suggestion['title'],
-      description: suggestion['description'],
-      subject: suggestion['subject'],
-      learning_goal: suggestion['learning_goal'],
-      interest: suggestion['interest'],
+    project_info = {
+      name: formatted_suggestion[1].split(":")[1].to_s.strip,
+      description: formatted_suggestion[2].split(":")[1].to_s.strip,
+      subject: formatted_suggestion[4].split(":")[1].to_s.strip,
+      learning_goal: formatted_suggestion[8].split(":")[1].to_s.strip,
+      interest: formatted_suggestion[10].split(":")[1].to_s.strip,
+      # steps: formatted_suggestion[12..16].map { |step| step.strip if step.present? },  # Extract and format steps
+      # vocab_words: formatted_suggestion[18..-1].map { |word| word.strip if word.present? },  # Extract and format vocab words
       status: 'pending',
       user: current_user
-    )
+    }
+
+    project_info
+  end
+
+
+  def project_params
+    params.require(:project).permit(:name, :deadline, :subject, :learning_goal, :status, :description, :interest, :steps, :vocab_words)
   end
 end

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -12,18 +12,13 @@
       </div>
       <% end %>
 
-      <div class="recommended-projects">
-        <div class="suggested-project-card">
-          <% @recommendation["suggested_project"].each do |line| %>
-            <% if line.starts_with?("Title:") || line.blank? %>
-              <h4><%= line unless line.blank? %></h4>
-            <% else %>
-              <p><%= line %></p>
-            <% end %>
-          <% end %>
-        </div>
-      </div>
+    <div class="suggested-project-card">
+      <h4>Newly Created Project</h4>
+      <h5><%= @project.name %></h5>
+      <p><strong>Subject:</strong> <%= @project.subject %></p>
+      <p><strong>Learning Goal:</strong> <%= @project.learning_goal %></p>
     </div>
+  </div>
   </div>
 </div>
 <%= render "shared/footer" %>


### PR DESCRIPTION
Okaaaayyyy so like I mentioned before, the previous way I created projects from Chat GPT made it difficult to create instances of projects.

This branch has instances of projects being created once the user clicks create project.

I think this way is easier, but I still can't get all of the attributes of the instance assigned to the right value.

We don't have to merge this branch if everyone would rather discuss first.

If we do decide to merge this branch, I copy pasted the previous way that I made projects so we can always go back to that version after discussing.


It's still not 100% working but if you look at my terminal screenshot you can see the prompt working and the formatted suggestions working as well! It's just the create method not making the instance exactly how we want it.

I also checked in rails c and it did look like the instances were being created, just with some nil values and misplaced attributes.

<img width="448" alt="Screen Shot 2023-08-15 at 12 47 57" src="https://github.com/KarasuGummi/ontrack/assets/115050264/7e6bb96c-b39b-435a-80bf-f2fc5382c348">

<img width="761" alt="Screen Shot 2023-08-15 at 12 48 20" src="https://github.com/KarasuGummi/ontrack/assets/115050264/89e874fe-639d-4c56-90a0-eabc09274049">

