### PR TITLE
moved the head info for bootstrap just to questions/index.html.erb fi…

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,10 +8,7 @@
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
     <%= favicon_link_tag 'pawprint.png' %>
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
-    <%= stylesheet_link_tag "https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" %>
+
   </head>
   <body>
     <%# <%= render "shared/navbar" %>

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -1,40 +1,49 @@
-<div class="container">
-  <div class="jumbotron">
-    <h3>Quiz time</h3>
-  </div>
+<head>
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <%= stylesheet_link_tag "https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" %>
+</head>
 
-  <%# Questions iterations %>
-  <% @questions.each_with_index do |question, index| %>
-    <div class="card border-info mb-4">
-      <div class="d-flex justify-content-between align-items-center card-header bg-info text-white" id="q<%= index + 1 %>_heading">
-        <span>Question <%= index + 1 %></span>
-        <button type="button" data-toggle="collapse" data-target="#q<%= index + 1 %>_collapse" aria-expanded="false" aria-controls="q<%= index + 1 %>_collapse" class="btn btn-outline-light">
-          <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-chevron-down" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-            <path fill-rule="evenodd" d="M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z" />
-          </svg>
-        </button>
-      </div>
-      <div id="q<%= index + 1 %>_collapse" class="collapse show" aria-labelledby="q<%= index + 1 %>_heading">
-        <div class="card-body">
-          <p><%= question.question_content %></p>
-          <% question.answers.each do |answer| %>
-            <div class="form-check">
-              <input class="form-check-input" type="radio" name="q<%= question.id %>" id="q<%= question.id %>_a<%= answer.id %>" value="<%= answer.id %>">
-              <label class="form-check-label" for="q<%= question.id %>_a<%= answer.id %>"><%= answer.answer_content %></label>
-            </div>
-          <% end %>
+<body>
+  <div class="container">
+    <div class="jumbotron">
+      <h3>Quiz time</h3>
+    </div>
+
+    <%# Questions iterations %>
+    <% @questions.each_with_index do |question, index| %>
+      <div class="card border-info mb-4">
+        <div class="d-flex justify-content-between align-items-center card-header bg-info text-white" id="q<%= index + 1 %>_heading">
+          <span>Question <%= index + 1 %></span>
+          <button type="button" data-toggle="collapse" data-target="#q<%= index + 1 %>_collapse" aria-expanded="false" aria-controls="q<%= index + 1 %>_collapse" class="btn btn-outline-light">
+            <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-chevron-down" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+              <path fill-rule="evenodd" d="M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z" />
+            </svg>
+          </button>
+        </div>
+        <div id="q<%= index + 1 %>_collapse" class="collapse show" aria-labelledby="q<%= index + 1 %>_heading">
+          <div class="card-body">
+            <p><%= question.question_content %></p>
+            <% question.answers.each do |answer| %>
+              <div class="form-check">
+                <input class="form-check-input" type="radio" name="q<%= question.id %>" id="q<%= question.id %>_a<%= answer.id %>" value="<%= answer.id %>">
+                <label class="form-check-label" for="q<%= question.id %>_a<%= answer.id %>"><%= answer.answer_content %></label>
+              </div>
+            <% end %>
+          </div>
         </div>
       </div>
-    </div>
-  <% end %>
-  <h3>Result</h3>
-  <div class="card">
-    <div class="card-body">
-      <p id="result">No result.</p>
-      <div class="progress mb-2">
-        <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
+    <% end %>
+    <h3>Result</h3>
+    <div class="card">
+      <div class="card-body">
+        <p id="result">No result.</p>
+        <div class="progress mb-2">
+          <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
+        </div>
+        <button type="button" class="btn btn-success">Submit</button>
       </div>
-      <button type="button" class="btn btn-success">Submit</button>
     </div>
   </div>
-</div>
+</body>


### PR DESCRIPTION
…le...

I copy pasted these lines from the application.html.erb file and moved them into the questions/index.html.erb file:

<img width="767" alt="Screen Shot 2023-08-15 at 17 48 42" src="https://github.com/KarasuGummi/ontrack/assets/115050264/acadcb06-845d-460f-bc39-efde4035f6f9">

<img width="546" alt="Screen Shot 2023-08-15 at 17 50 41" src="https://github.com/KarasuGummi/ontrack/assets/115050264/c72a3a8f-dc78-474c-82e8-7feaa90c7d15">

<img width="553" alt="Screen Shot 2023-08-15 at 17 50 56" src="https://github.com/KarasuGummi/ontrack/assets/115050264/c720a9b8-9b7e-4a5b-9872-ec115ffc5f6c">


I think we can now use bootstrap for the quiz without breaking the other pages 🙂 👍
The quiz page does look nice so I think it's nice to keep using bootstrap there as long as everything else works.