### PR TITLE
Change redirect for project create

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -120,7 +120,7 @@ class ProjectsController < ApplicationController
   def generate_recommendations(subject, learning_goal, user_interest)
     prompt = <<~PROMPT
       Please suggest one project for my class.
-      Please limit the words of the description for the project to less than 12 words.
+      Please limit the words of the description for the project to less than 15 words.
       Please also limit the instructions to 4 steps with each step having less than 12 words.
       The project should be about my learning and the project should incorporate my interest.
       There should only be 5 vocab words per project as strings in an array.

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -46,7 +46,7 @@ class ProjectsController < ApplicationController
         project_to_accept.update(status: 'accepted')
         flash[:notice] = 'Recommended project added!'
       end
-      # redirect_to projects_path
+      redirect_to project_path(@project)
     else
       puts "Project Errors: #{@project.errors}"
       render 'new'

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -14,12 +14,12 @@
       </div>
       <% end %>
 
-    <div class="suggested-project-card">
+    <%# <div class="suggested-project-card">
       <h4>Newly Created Project</h4>
-      <h5><%= @project.name %></h5>
-      <p><strong>Subject:</strong> <%= @project.subject %></p>
-      <p><strong>Learning Goal:</strong> <%= @project.learning_goal %></p>
-    </div>
+      <h5><%= @project.name %>
+      <%# <p><strong>Subject:</strong> <%= @project.subject %>
+      <%# <p><strong>Learning Goal:</strong> <%= @project.learning_goal %>
+    <%# </div> %>
   </div>
   </div>
 </div>

--- a/db/migrate/20230816030720_remove_steps_from_projects.rb
+++ b/db/migrate/20230816030720_remove_steps_from_projects.rb
@@ -1,0 +1,5 @@
+class RemoveStepsFromProjects < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :projects, :steps
+  end
+end

--- a/db/migrate/20230816030807_add_steps_to_projects.rb
+++ b/db/migrate/20230816030807_add_steps_to_projects.rb
@@ -1,0 +1,5 @@
+class AddStepsToProjects < ActiveRecord::Migration[7.0]
+  def change
+    add_column :projects, :steps, :string, array: true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_12_123625) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_16_030807) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -77,8 +77,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_12_123625) do
     t.text "description"
     t.string "interest"
     t.string "learning_goal"
-    t.text "steps"
     t.string "vocab_words", default: [], array: true
+    t.string "steps", default: [], array: true
     t.index ["user_id"], name: "index_projects_on_user_id"
   end
 


### PR DESCRIPTION
I did a few small changes:
- changed steps from a text to an array of strings in the schema for projects
- changed the redirect in projects#create so we're directed to the projects/:id show page after making a new project (Now we're able to add new projects from chat gpt by updating the status) 🥳

This project came from Chat GPT ->
<img width="489" alt="Screen Shot 2023-08-16 at 12 12 49" src="https://github.com/KarasuGummi/ontrack/assets/115050264/06eab5f1-4345-4b38-9fb4-c784a9f73e7e">



