### PR TITLE
Project status button

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -2,5 +2,5 @@ class Project < ApplicationRecord
   belongs_to :user
   has_many :questions, dependent: :delete_all
 
-  enum status: { pending: 0, accepted: 1, completed: 2 }, _default: 0
+  enum status: { pending: 0, accepted: 1, completed: 2, declined: 3 }, _default: 0
 end

--- a/app/views/projects/dashboard.html.erb
+++ b/app/views/projects/dashboard.html.erb
@@ -12,10 +12,10 @@
       <%# display latest project %>
       <div class="latest-project">
         <% if @latest_project %>
-          <h6>Latest Project</h6>
+          <h6>Latest Track</h6>
           <p class="dashboard-label"><strong><%= @latest_project.name %></strong></p>
         <% else %>
-          <p class="dashboard-label">No project added yet.</p>
+          <p class="dashboard-label">No tracks added yet.</p>
         <% end %>
         <%# display upcoming deadlines %>
 
@@ -47,7 +47,7 @@
 </div>
 <div class="dashboard-add-btn">
   <button class="blue-btn">
-    <%= link_to "Add New Project", new_project_path%>
+    <%= link_to "Add New Track", new_project_path%>
   </button>
 </div>
 
@@ -56,7 +56,7 @@
   <% if @recommended_projects.any? %>
   <div class="card text-center">
     <div class="card-header">
-      Try one of these projects!
+      Try one of these tracks!
     </div>
     <% @recommended_projects.each do |project| %>
     <div class="card-body">

--- a/app/views/projects/history.html.erb
+++ b/app/views/projects/history.html.erb
@@ -7,6 +7,8 @@
       <div class="projects-page-title col-12 col-lg-6">
         <div class="title">
           <h1>Completed Learning Tracks</h1>
+          <%= link_to 'Return to Current Learning Tracks', projects_path, class: "small-link" %>
+
         </div>
 
         <div class="paw">

--- a/app/views/projects/history.html.erb
+++ b/app/views/projects/history.html.erb
@@ -7,7 +7,7 @@
       <div class="projects-page-title col-12 col-lg-6">
         <div class="title">
           <h1>Completed Learning Tracks</h1>
-          <%= link_to 'Return to Current Learning Tracks', projects_path, class: "small-link" %>
+          <%= link_to 'Return to Current Tracks', projects_path, class: "small-link" %>
 
         </div>
 

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -45,7 +45,7 @@
           <% end %>
       </div>
           <% else %>
-            <p>No project</p>
+            <p>You currently don't have any Learning Tracks. Time to start something new!!</p>
           <% end %>
 
       <%# <div class="add-btn">

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -7,7 +7,7 @@
       <div class="projects-page-title col-12 col-lg-6">
         <div class="title">
             <h1>My Learning Tracks</h1>
-        <%= link_to 'Completed Projects', history_path, class: "small-link" %>
+        <%= link_to 'Completed Tracks', history_path, class: "small-link" %>
         </div>
 
         <%# paw %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -52,10 +52,10 @@
         <h6><strong><%= @project.name %></strong></h6>
         <p><%= @project.description%></p>
 
-        <h6><strong>Project Steps:</strong></h6>
+        <h6><strong>Key Steps:</strong></h6>
         <ul>
           <% @project.steps.each_with_index do |step, index| %>
-            <li><%= "#{index + 1}. #{step}"  %></li>
+            <li><%= "Step #{index + 1}: #{step}"  %></li>
           <% end %>
         </ul>
 
@@ -63,7 +63,7 @@
 
 
 
-        <h6><strong>Vocab Words:</strong></h6>
+        <h6><strong>Key Words:</strong></h6>
         <ul>
           <% @project.vocab_words.each do |word| %>
             <li><%= word %></li>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -22,7 +22,8 @@
           <div class="category-tag">
             <p class="subject-tag"><%= @project.subject %></p>
           </div>
-            <%# Update a pending project to accepted to display in projects list %>
+
+          <%# Buttons for pending projects %>
           <% if @project.pending? %>
             <%= simple_form_for @project, url: project_path(@project) do |f| %>
             <%= f.input :status, as: :hidden, input_html: { value: 'accepted' } %>
@@ -36,6 +37,8 @@
               <%= f.submit 'Decline', class: 'yellow-btn' %>
             </div>
             <% end %>
+
+          <%# Buttons for accepted projects %>
           <% elsif @project.accepted? %>
             <%= simple_form_for @project, url: project_path(@project) do |f| %>
             <%= f.input :status, as: :hidden, input_html: { value: 'completed' } %>
@@ -45,11 +48,20 @@
             <% end %>
           <% end %>
         </div>
+
         <h6><strong><%= @project.name %></strong></h6>
         <p><%= @project.description%></p>
 
         <h6><strong>Project Steps:</strong></h6>
-        <p><%= @project.steps %></p>
+        <ul>
+          <% @project.steps.each_with_index do |step, index| %>
+            <li><%= "#{index + 1}. #{step}"  %></li>
+          <% end %>
+        </ul>
+
+
+
+
 
         <h6><strong>Vocab Words:</strong></h6>
         <ul>
@@ -64,17 +76,47 @@
       </div>
     </div>
 
-    <div class="showpage-projects-card show-status">
-      <div class="show-status-content">
-        <h6><strong>Status:</strong></h6>
-        <p>My Progress:</p>
-          <div class="progBar">
-              <p class="bar"></p>
-          </div>
-        <p>Key Concepts Learned:</p>
-        <p>Points earned: +<%= @project.points %></p>
+    <%# Status card for pending projects %>
+    <% if @project.pending? %>
+      <div class="showpage-projects-card show-status">
+        <div class="show-status-content">
+          <h6><strong>Status:</strong></h6>
+          <p>Key Concepts:</p>
+          <p>Potential Points: <%= @project.points %></p>
+        </div>
       </div>
-    </div>
+
+    <%# Status card for accepted projects %>
+    <% elsif @project.accepted? %>
+      <div class="showpage-projects-card show-status">
+        <div class="show-status-content">
+          <h6><strong>Status:</strong></h6>
+          <p>My Progress:</p>
+            <div class="progBar">
+                <p class="bar"></p>
+            </div>
+          <p>Key Concepts:</p>
+          <p>Points: +<%= @project.points %></p>
+        </div>
+      </div>
+
+    <%# Status card for completed project %>
+    <% elsif @project.completed? %>
+      <div class="showpage-projects-card show-status">
+        <div class="show-status-content">
+          <h6><strong>Status:</strong></h6>
+          <p>Completed!</p>
+            <div class="progBar">
+                <p class="bar"></p>
+            </div>
+          <p>Key Concepts Learned:</p>
+          <p>Points earned: +<%= @project.points %></p>
+        </div>
+      </div>
+
+    <% end %>
+
+
     <div class="buddy-part">
         <%= cl_image_tag("https://res.cloudinary.com/dbmqippyl/image/upload/v1691307874/buddy-face_inetw9.png", height: 50, crop: :fill, class: "buddy-avatar")%>
       <div class="chatting">

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -30,6 +30,12 @@
               <%= f.submit 'Add', class: 'green-btn' %>
             </div>
             <% end %>
+            <%= simple_form_for @project, url: project_path(@project) do |f| %>
+            <%= f.input :status, as: :hidden, input_html: { value: 'declined' } %>
+            <div class="button-container">
+              <%= f.submit 'Decline', class: 'yellow-btn' %>
+            </div>
+            <% end %>
           <% end %>
         </div>
         <h6><strong><%= @project.name %></strong></h6>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -36,6 +36,13 @@
               <%= f.submit 'Decline', class: 'yellow-btn' %>
             </div>
             <% end %>
+          <% elsif @project.accepted? %>
+            <%= simple_form_for @project, url: project_path(@project) do |f| %>
+            <%= f.input :status, as: :hidden, input_html: { value: 'completed' } %>
+            <div class="button-container">
+              <%= f.submit 'Complete', class: 'blue-btn' %>
+            </div>
+            <% end %>
           <% end %>
         </div>
         <h6><strong><%= @project.name %></strong></h6>


### PR DESCRIPTION
Hello!
I made a few small updates on the projects#show and indexes pages....

I basically just added more buttons for updating statuses.

A user can now choose to accept or decline a recommending project (these are projects with a pending status).

A user can also mark an accepted project as completed.

I just used the yellow/green/blue button scss classes that we already had.

The styling needs to be updated, but the backend is working so I wanted to push it 😆

<img width="474" alt="Screen Shot 2023-08-17 at 13 49 24" src="https://github.com/KarasuGummi/ontrack/assets/115050264/afae9537-c539-4445-9ea3-0b6f70961beb">

<img width="476" alt="Screen Shot 2023-08-17 at 13 50 49" src="https://github.com/KarasuGummi/ontrack/assets/115050264/df759201-259d-4cd2-a9fa-9ff0f6975708">

