### PR TITLE
Fix the style in project index page

### DIFF
--- a/app/assets/stylesheets/components/_flashcard.scss
+++ b/app/assets/stylesheets/components/_flashcard.scss
@@ -18,11 +18,12 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  
+  .content {
+    text-align: center;
+  }
 }
 .card-inner.answer {
   transform: rotateX(180deg);
   height: 300px;
-}
-.content {
-  text-align: center;
 }


### PR DESCRIPTION
Moved ".content" styling to inside ".card-inner" to fix the styling of project index page:)
![content](https://github.com/KarasuGummi/ontrack/assets/111837513/6a096a80-c87b-4652-911d-37e6780fcabe)
![project index](https://github.com/KarasuGummi/ontrack/assets/111837513/14ed9b29-6fc7-4f62-ab7e-58123c829ce5)
